### PR TITLE
Add support for target-text-channels for Slash Commands

### DIFF
--- a/src/main/java/uk/co/angrybee/joe/DiscordClient.java
+++ b/src/main/java/uk/co/angrybee/joe/DiscordClient.java
@@ -330,7 +330,7 @@ public class DiscordClient extends ListenerAdapter {
 
         if (!Arrays.asList(targetTextChannels).contains(event.getTextChannel().getId())) {
             MessageEmbed messageEmbed = CreateEmbeddedMessage("Sorry!",
-                    ("This bot can only used in the specified chcannel."), EmbedMessageType.FAILURE).build();
+                    ("This bot can only used in the specified channel."), EmbedMessageType.FAILURE).build();
             ReplyAndRemoveAfterSeconds(event, messageEmbed);
             return;
         }

--- a/src/main/java/uk/co/angrybee/joe/DiscordClient.java
+++ b/src/main/java/uk/co/angrybee/joe/DiscordClient.java
@@ -328,6 +328,13 @@ public class DiscordClient extends ListenerAdapter {
             return;
         }
 
+        if (!Arrays.asList(targetTextChannels).contains(event.getTextChannel().getId())) {
+            MessageEmbed messageEmbed = CreateEmbeddedMessage("Sorry!",
+                    ("This bot can only used in the specified chcannel."), EmbedMessageType.FAILURE).build();
+            ReplyAndRemoveAfterSeconds(event, messageEmbed);
+            return;
+        }
+
         String subcommand = event.getSubcommandName();
         OptionMapping mc_name_op = event.getOption("minecraft_username");
         String mc_name = null;


### PR DESCRIPTION
Currently the config for target-text-channels its not been used in Slash commands, this PR add this support again.